### PR TITLE
LIBSEARCH-72. Changed user search query processing to be more permissive

### DIFF
--- a/app/searchers/quick_search/lib_answers_searcher.rb
+++ b/app/searchers/quick_search/lib_answers_searcher.rb
@@ -28,13 +28,21 @@ module QuickSearch
 
     def search_url
       QuickSearch::Engine::LIB_ANSWERS_CONFIG['base_url'] +
-        http_request_queries['uri_escaped'] +
+        CGI.escape(sanitized_user_search_query) +
         QuickSearch::Engine::LIB_ANSWERS_CONFIG['query_params']
     end
 
     def loaded_link
       QuickSearch::Engine::LIB_ANSWERS_CONFIG['loaded_link'] +
-        http_request_queries['uri_escaped']
+        sanitized_user_search_query
+    end
+
+    # Returns the sanitized search query entered by the user, skipping
+    # the default QuickSearch query filtering
+    def sanitized_user_search_query
+      # Need to use "to_str" as otherwise Japanese text isn't returned
+      # properly
+      sanitize(@q).to_str
     end
 
     def total


### PR DESCRIPTION
The default QuickSearch user search query processing is very
restrictive, and prevents some common searches, such as those with
dashes. There were also difficulties with using search terms in foreign
languages such as Japanese.

Added "sanitized_user_search_query" method to return the user search
query that has only been passed through the "sanitize" method, which
results in a broader range of queries than that allows the default
QuickSearch user search query processing.

It is possible that even the "sanitize" method is not needed, but is
used here for whatever marginal benefit it might provide.

https://issues.umd.edu/browse/LIBSEARCH-72